### PR TITLE
remove unnecessary crypto package

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,9 +30,7 @@
     "url": "https://github.com/mirceaalexandru/seneca-crypt/issues"
   },
   "homepage": "https://github.com/mirceaalexandru/seneca-crypt",
-  "dependencies": {
-    "crypto": "0.0.3"
-  },
+  "dependencies": {},
   "peerDependencies": {
     "seneca": "*"
   },


### PR DESCRIPTION
See https://medium.com/@rmehlinger/crypto-collision-f41c206de27b. This package has no license and no tests, and masks a built in NodeJS library. Thankfully, Node does not allow its crypto package to be overwritten by this thing, so requiring it doesn't actually do anything.